### PR TITLE
solana: some changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get solana version
         id: solana
         run: |
-          SOLANA_VERSION="$(awk '/solana-program =/ { print substr($3, 3, length($3)-3) }' solana/programs/example-native-token-transfers/Cargo.toml)"
+          SOLANA_VERSION="$(awk '/solana-program =/ { print substr($3, 3, length($3)-3) }' solana/Cargo.toml)"
           echo "::set-output name=version::${SOLANA_VERSION}"
 
       - name: Cache rust toolchain

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.12",
@@ -1485,7 +1485,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 name = "example-native-token-transfers"
 version = "0.1.0"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.5",
  "anchor-lang",
  "anchor-spl",
  "base64 0.21.7",
@@ -1508,6 +1508,7 @@ dependencies = [
  "wormhole-io",
  "wormhole-raw-vaas",
  "wormhole-sdk",
+ "wormhole-solana-utils",
 ]
 
 [[package]]
@@ -1773,7 +1774,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.5",
 ]
 
 [[package]]
@@ -3872,7 +3873,7 @@ version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "098378043a888c680de07eee987bf927e23e0720b472ba61c753d7b3757e6b3e"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.5",
  "blake3",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -3985,7 +3986,7 @@ version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcffede3b37ccdddbd57f93e4228b268f05c0a5cb44cb6e382ed8a31a15f5573"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.5",
  "bincode",
  "bv",
  "caps",
@@ -5927,6 +5928,16 @@ dependencies = [
  "serde_wormhole",
  "sha3 0.10.8",
  "thiserror",
+]
+
+[[package]]
+name = "wormhole-solana-utils"
+version = "0.2.0-alpha.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae4412bb88773852fe58215601cda7d8f7f0204a700526f25a9ece951715774"
+dependencies = [
+ "anchor-lang",
+ "solana-program",
 ]
 
 [[package]]

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -4,6 +4,20 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+wormhole-io = "0.1.3"
+wormhole-solana-utils = "0.2.0-alpha.15"
+
+anchor-lang = "0.29.0"
+anchor-spl = "0.29.0"
+solana-program = "=1.17.2"
+
+wormhole-anchor-sdk = "0.29.0-alpha.1"
+wormhole-sdk = { git = "https://github.com/wormhole-foundation/wormhole", rev = "eee4641" }
+serde_wormhole = { git = "https://github.com/wormhole-foundation/wormhole", rev = "eee4641" }
+
+hex = "0.4.3"
+
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/solana/programs/example-native-token-transfers/Cargo.toml
+++ b/solana/programs/example-native-token-transfers/Cargo.toml
@@ -20,31 +20,30 @@ idl-build = [
 ]
 
 [dependencies]
-ahash = "=0.8.6"
+ahash = "=0.8.5"
 
-anchor-lang = { version = "0.29.0", features = ["init-if-needed"] }
-anchor-spl = "0.29.0"
+anchor-lang = { workspace = true, features = ["init-if-needed"] }
+anchor-spl.workspace = true
 bitmaps = "3.2.1"
-hex = "0.4.3"
-solana-program = "=1.17.2"
-wormhole-anchor-sdk = "0.29.0-alpha.1"
-wormhole-io = "0.1.3"
+hex.workspace = true
+solana-program.workspace = true
+wormhole-anchor-sdk.workspace = true
+wormhole-io.workspace = true
+wormhole-solana-utils.workspace = true
 
 [dev-dependencies]
-hex = "0.4.3"
-
 wormhole-governance = { path = "../wormhole-governance", features = ["no-entrypoint"] }
-solana-program-test = "1.17.2"
+solana-program-test = "*"
 serde_json = "1.0.113"
 serde = "1.0.196"
 base64 = "0.21.7"
-solana-sdk = "1.17.2"
+solana-sdk = "*"
 spl-token = "4"
 spl-associated-token-account = "2.2.0"
 sha3 = "0.10.4"
 wormhole-raw-vaas = "0.2.0-alpha.2"
 libsecp256k1 = "=0.6.0"
-wormhole-sdk = { git = "https://github.com/wormhole-foundation/wormhole", rev = "eee4641" }
-serde_wormhole = { git = "https://github.com/wormhole-foundation/wormhole", rev = "eee4641" }
+wormhole-sdk.workspace = true
+serde_wormhole.workspace = true
 solana-program-runtime = "1.17.2"
 bincode = "1.3.3"

--- a/solana/programs/example-native-token-transfers/src/error.rs
+++ b/solana/programs/example-native-token-transfers/src/error.rs
@@ -31,4 +31,6 @@ pub enum NTTError {
     Paused,
     #[msg("DisabledEndpoint")]
     DisabledEndpoint,
+    #[msg("InvalidDeployer")]
+    InvalidDeployer,
 }

--- a/solana/programs/example-native-token-transfers/src/instructions/initialize.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/initialize.rs
@@ -63,7 +63,7 @@ pub struct Initialize<'info> {
     pub rate_limit: Account<'info, OutboxRateLimit>,
 
     #[account(
-        seeds = [b"token_authority"],
+        seeds = [crate::TOKEN_AUTHORITY_SEED],
         bump,
     )]
     pub token_authority: AccountInfo<'info>,

--- a/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs
+++ b/solana/programs/example-native-token-transfers/src/instructions/release_inbound.rs
@@ -25,7 +25,7 @@ pub struct ReleaseInbound<'info> {
     pub recipient: InterfaceAccount<'info, token_interface::TokenAccount>,
 
     #[account(
-        seeds = [b"token_authority"],
+        seeds = [crate::TOKEN_AUTHORITY_SEED],
         bump,
     )]
     pub token_authority: AccountInfo<'info>,
@@ -85,7 +85,10 @@ pub fn release_inbound_mint(
                     to: ctx.accounts.common.recipient.to_account_info(),
                     authority: ctx.accounts.common.token_authority.clone(),
                 },
-                &[&[b"token_authority", &[ctx.bumps.common.token_authority]]],
+                &[&[
+                    crate::TOKEN_AUTHORITY_SEED,
+                    &[ctx.bumps.common.token_authority],
+                ]],
             ),
             inbox_item.amount,
         ),
@@ -139,7 +142,10 @@ pub fn release_inbound_unlock(
                     authority: ctx.accounts.common.token_authority.clone(),
                     mint: ctx.accounts.common.mint.to_account_info(),
                 },
-                &[&[b"token_authority", &[ctx.bumps.common.token_authority]]],
+                &[&[
+                    crate::TOKEN_AUTHORITY_SEED,
+                    &[ctx.bumps.common.token_authority],
+                ]],
             ),
             inbox_item.amount,
             ctx.accounts.common.mint.decimals,

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -62,11 +62,8 @@ pub mod example_native_token_transfers {
         instructions::release_inbound_unlock(ctx, args)
     }
 
-    pub fn transfer_ownership(
-        ctx: Context<TransferOwnership>,
-        args: TransferOwnershipArgs,
-    ) -> Result<()> {
-        instructions::transfer_ownership(ctx, args)
+    pub fn transfer_ownership(ctx: Context<TransferOwnership>) -> Result<()> {
+        instructions::transfer_ownership(ctx)
     }
 
     pub fn claim_ownership(ctx: Context<ClaimOwnership>) -> Result<()> {

--- a/solana/programs/example-native-token-transfers/src/lib.rs
+++ b/solana/programs/example-native-token-transfers/src/lib.rs
@@ -20,6 +20,8 @@ use instructions::*;
 
 declare_id!("F2DDaJgSfJTVYVjVkxmsFYy771QgXfqCjanF7nRQt4HV");
 
+const TOKEN_AUTHORITY_SEED: &[u8] = b"token_authority";
+
 #[program]
 pub mod example_native_token_transfers {
 

--- a/solana/programs/example-native-token-transfers/tests/cancel_flow.rs
+++ b/solana/programs/example-native-token-transfers/tests/cancel_flow.rs
@@ -16,7 +16,10 @@ use solana_program_test::*;
 use solana_sdk::{signature::Keypair, signer::Signer};
 use wormhole_sdk::{Address, Vaa};
 
-use crate::{common::submit::Submittable, sdk::instructions::transfer::transfer};
+use crate::{
+    common::submit::Submittable,
+    sdk::instructions::transfer::{approve_token_authority, transfer},
+};
 use crate::{
     common::{query::GetAccountDataAnchor, setup::setup},
     sdk::{
@@ -194,6 +197,15 @@ async fn test_cancel() {
     let (accs, args) =
         init_transfer_accs_args(&mut ctx, &test_data, outbox_item.pubkey(), 7000, true);
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await

--- a/solana/programs/example-native-token-transfers/tests/sdk/accounts.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/accounts.rs
@@ -12,6 +12,7 @@ use example_native_token_transfers::{
 use sha3::{Digest, Keccak256};
 use wormhole_anchor_sdk::wormhole;
 use wormhole_io::TypePrefixedPayload;
+use wormhole_solana_utils::cpi::bpf_loader_upgradeable;
 
 pub struct Wormhole {
     pub program: Pubkey,
@@ -178,5 +179,16 @@ impl NTT {
 
     pub fn wormhole_sequence(&self) -> Pubkey {
         self.wormhole.sequence(&self.emitter())
+    }
+
+    pub fn program_data(&self) -> Pubkey {
+        let (addr, _) =
+            Pubkey::find_program_address(&[self.program.as_ref()], &bpf_loader_upgradeable::id());
+        addr
+    }
+
+    pub fn upgrade_lock(&self) -> Pubkey {
+        let (addr, _) = Pubkey::find_program_address(&[b"upgrade-lock"], &self.program);
+        addr
     }
 }

--- a/solana/programs/example-native-token-transfers/tests/sdk/instructions/initialize.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/instructions/initialize.rs
@@ -2,21 +2,24 @@ use anchor_lang::{prelude::Pubkey, system_program::System, Id, InstructionData, 
 use anchor_spl::{associated_token::AssociatedToken, token::Token};
 use example_native_token_transfers::instructions::InitializeArgs;
 use solana_sdk::instruction::Instruction;
+use wormhole_solana_utils::cpi::bpf_loader_upgradeable::BpfLoaderUpgradeable;
 
 use crate::sdk::accounts::NTT;
 
 pub struct Initialize {
     pub payer: Pubkey,
-    pub owner: Pubkey,
+    pub deployer: Pubkey,
     pub mint: Pubkey,
 }
 
 pub fn initialize(ntt: &NTT, accounts: Initialize, args: InitializeArgs) -> Instruction {
     let data = example_native_token_transfers::instruction::Initialize { args };
 
+    let bpf_loader_upgradeable_program = BpfLoaderUpgradeable::id();
     let accounts = example_native_token_transfers::accounts::Initialize {
         payer: accounts.payer,
-        owner: accounts.owner,
+        deployer: accounts.deployer,
+        program_data: ntt.program_data(),
         config: ntt.config(),
         mint: accounts.mint,
         seq: ntt.sequence(),
@@ -25,6 +28,7 @@ pub fn initialize(ntt: &NTT, accounts: Initialize, args: InitializeArgs) -> Inst
         custody: ntt.custody(&accounts.mint),
         token_program: Token::id(),
         associated_token_program: AssociatedToken::id(),
+        bpf_loader_upgradeable_program,
         system_program: System::id(),
     };
 

--- a/solana/programs/example-native-token-transfers/tests/sdk/instructions/transfer.rs
+++ b/solana/programs/example-native-token-transfers/tests/sdk/instructions/transfer.rs
@@ -65,7 +65,7 @@ pub fn approve_token_authority(
         &spl_token::id(), // TODO: look into how token account was originally created
         user_token_account,
         &ntt.token_authority(),
-        &user,
+        user,
         &[user],
         amount,
     )

--- a/solana/programs/example-native-token-transfers/tests/transfer.rs
+++ b/solana/programs/example-native-token-transfers/tests/transfer.rs
@@ -26,7 +26,7 @@ use crate::{
     common::submit::Submittable,
     sdk::instructions::{
         admin::{set_paused, SetPaused},
-        transfer::transfer,
+        transfer::{approve_token_authority, transfer},
     },
 };
 use crate::{
@@ -99,6 +99,15 @@ async fn test_transfer(ctx: &mut ProgramTestContext, test_data: &TestData, mode:
 
     let (accs, args) = init_accs_args(ctx, test_data, outbox_item.pubkey(), 100, false);
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, mode)
         .submit_with_signers(&[&test_data.user, &outbox_item], ctx)
         .await
@@ -198,6 +207,15 @@ async fn test_burn_mode_burns_tokens() {
         .get_account_data_anchor(test_data.user_token_account)
         .await;
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, Mode::Burning)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await
@@ -237,6 +255,15 @@ async fn locking_mode_locks_tokens() {
 
     let mint_before: Mint = ctx.get_account_data_anchor(test_data.mint).await;
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await
@@ -281,6 +308,15 @@ async fn test_rate_limit() {
         .get_account_data_anchor(test_data.ntt.outbox_rate_limit())
         .await;
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await
@@ -303,6 +339,15 @@ async fn test_transfer_wrong_mode() {
 
     let (accs, args) = init_accs_args(&mut ctx, &test_data, outbox_item.pubkey(), 100, false);
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     // make sure we can't transfer in the wrong mode
     let err = transfer(&test_data.ntt, accs.clone(), args.clone(), Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
@@ -347,6 +392,15 @@ async fn test_large_tx_queue() {
         .get_account_data_anchor(test_data.ntt.outbox_rate_limit())
         .await;
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await
@@ -381,6 +435,15 @@ async fn test_cant_transfer_when_paused() {
     .await
     .unwrap();
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     let err = transfer(&test_data.ntt, accs.clone(), args.clone(), Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await
@@ -403,6 +466,15 @@ async fn test_cant_transfer_when_paused() {
     .await
     .unwrap();
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await
@@ -425,6 +497,15 @@ async fn test_large_tx_no_queue() {
         should_queue,
     );
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     let err = transfer(&test_data.ntt, accs, args, Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await
@@ -448,6 +529,15 @@ async fn test_cant_release_queued() {
     let too_much = OUTBOUND_LIMIT + 1000;
     let (accs, args) = init_accs_args(&mut ctx, &test_data, outbox_item.pubkey(), too_much, true);
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await
@@ -513,6 +603,15 @@ async fn test_cant_release_twice() {
 
     let (accs, args) = init_accs_args(&mut ctx, &test_data, outbox_item.pubkey(), 100, false);
 
+    approve_token_authority(
+        &test_data.ntt,
+        &test_data.user_token_account,
+        &test_data.user.pubkey(),
+        args.amount,
+    )
+    .submit_with_signers(&[&test_data.user], &mut ctx)
+    .await
+    .unwrap();
     transfer(&test_data.ntt, accs, args, Mode::Locking)
         .submit_with_signers(&[&test_data.user, &outbox_item], &mut ctx)
         .await

--- a/solana/programs/wormhole-governance/Cargo.toml
+++ b/solana/programs/wormhole-governance/Cargo.toml
@@ -18,9 +18,9 @@ idl-build = [
 ]
 
 [dependencies]
-anchor-lang = "0.29.0"
+anchor-lang.workspace = true
+solana-program.workspace = true
 
-solana-program = "=1.17.2"
-wormhole-anchor-sdk = "0.29.0-alpha.1"
-wormhole-io = "0.1.3"
-wormhole-sdk = { git = "https://github.com/wormhole-foundation/wormhole", rev = "eee4641" }
+wormhole-anchor-sdk.workspace = true
+wormhole-io.workspace = true
+wormhole-sdk.workspace = true


### PR DESCRIPTION
* add set upgrade authority to transfer ownership instructions

* add sender as signer for outbound transfers

* require delegated authority to token authority for outbound transfers

* uptick solana 1.17.20